### PR TITLE
Fix + character

### DIFF
--- a/WhatsAppGDExtract.py
+++ b/WhatsAppGDExtract.py
@@ -110,7 +110,7 @@ class WaBackup:
         if not have_file(name, int(file["sizeBytes"]), md5Hash):
             download_file(
                 name,
-                self.get(file["name"].replace("%", "%25"), {"alt": "media"}, stream=True)
+                self.get(file["name"].replace("%", "%25").replace("+", "%2B"), {"alt": "media"}, stream=True)
             )
 
         return name, int(file["sizeBytes"]), md5Hash


### PR DESCRIPTION
If file name is as follows, it gives an 404 not found error.
file+name.txt

We need to change url like;
file%2Bname.txt