### PR TITLE
Fixed error on info option

### DIFF
--- a/WhatsAppGDExtract.py
+++ b/WhatsAppGDExtract.py
@@ -189,7 +189,7 @@ def backup_info(backup):
     metadata = json.loads(backup["metadata"])
     for size in "backupSize", "chatdbSize", "mediaSize", "videoSize":
         metadata[size] = human_size(int(metadata[size]))
-    print("Backup {} Size:({}) Upload Time:{}".format(backup["name"].split("/")[-1], metadata["backupSize"]), backup["updateTime"])
+    print("Backup {} Size:({}) Upload Time:{}".format(backup["name"].split("/")[-1], metadata["backupSize"], backup["updateTime"]))
     print("  WhatsApp version  : {}".format(metadata["versionOfAppWhenBackup"]))
     try:
         print("  Password protected: {}".format(metadata["passwordProtectedBackupEnabled"]))


### PR DESCRIPTION
Error encountered when using the info option:

```
Do you want XXXXXXXXXXX? [y/n] : y
Traceback (most recent call last):
  File "WhatsAppGDExtract.py", line 260, in <module>
    main(sys.argv)
  File "WhatsAppGDExtract.py", line 217, in main
    backup_info(backup)
  File "WhatsAppGDExtract.py", line 192, in backup_info
    print("Backup {} Size:({}) Upload Time:{}".format(backup["name"].split("/")[-1], metadata["backupSize"]), backup["updateTime"])
IndexError: tuple index out of range
```